### PR TITLE
Fix self not defined in exec call

### DIFF
--- a/mcp_server_fastmcp2.py
+++ b/mcp_server_fastmcp2.py
@@ -379,7 +379,7 @@ class FastMCP2Server:
         arguments = {{}}
 {chr(10).join([f'        if {param} is not None: arguments["{param}"] = {param}' for param in param_names])}
         
-        logger.info(f"Executing FastMCP 2.0 tool: {tool_name} with arguments: {{list(arguments.keys())}}")
+        logger.info(f"Executing FastMCP 2.0 tool: {{tool_name}} with arguments: {{list(arguments.keys())}}")
         
         # Get tool info from mapping
         tool_info = self.tool_name_mapping[tool_name]
@@ -396,17 +396,17 @@ class FastMCP2Server:
         
         if result.get("status") == "success":
             response_text = json.dumps(result.get("data", result), indent=2)
-            logger.info(f"Tool {tool_name} executed successfully")
+            logger.info(f"Tool {{tool_name}} executed successfully")
             return response_text
         else:
             error_msg = f"Tool execution failed: {{result.get('message', 'Unknown error')}}"
             if result.get('status_code'):
                 error_msg += f" (HTTP {{result['status_code']}})"
-            logger.error(f"Tool {tool_name} failed: {{error_msg}}")
+            logger.error(f"Tool {{tool_name}} failed: {{error_msg}}")
             return error_msg
             
     except Exception as e:
-        logger.error(f"Error executing tool {tool_name}: {{e}}", exc_info=True)
+        logger.error(f"Error executing tool {{tool_name}}: {{e}}", exc_info=True)
         return f"Error: {{str(e)}}"
 """
             


### PR DESCRIPTION
Escape `tool_name` in dynamically generated function f-strings to ensure correct variable scoping during execution.

The `tool_name` variable was being interpolated into the function string at creation time, rather than being passed as a variable to the dynamically executed function. This caused `tool_name` to not be correctly available within the function's scope, leading to errors when tools were called.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3d68fbf-fe38-480d-a803-8044bc30acf1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3d68fbf-fe38-480d-a803-8044bc30acf1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

