### PR TITLE
Fix tool message role validation

### DIFF
--- a/mcp_service.py
+++ b/mcp_service.py
@@ -171,6 +171,25 @@ class ModernLLMService:
         
             if choice.finish_reason == "tool_calls":
                 logger.info(f"🔄 [MCP_SERVICE] LLM requested {len(choice.message.tool_calls)} tool calls")
+                
+                # Add the assistant message with tool_calls to conversation history
+                assistant_message = {
+                    "role": "assistant",
+                    "content": choice.message.content or "",
+                    "tool_calls": [
+                        {
+                            "id": tool_call.id,
+                            "type": "function",
+                            "function": {
+                                "name": tool_call.function.name,
+                                "arguments": tool_call.function.arguments or "{}"
+                            }
+                        }
+                        for tool_call in choice.message.tool_calls
+                    ]
+                }
+                messages.append(assistant_message)
+                
                 # Handle tool calls with modern capabilities
                 for i, tool_call in enumerate(choice.message.tool_calls, 1):
                     tool_name = tool_call.function.name


### PR DESCRIPTION
Fixes Azure OpenAI tool call message flow and `safe_truncate` JSON serialization to resolve API errors.

The Azure OpenAI API requires an assistant message containing `tool_calls` to precede tool messages in the conversation history. This PR adds the assistant message to ensure the correct sequence, resolving the "Invalid parameter, messages with role tool must be a response to a preceding message with tool_calls" error. It also updates `safe_truncate` to properly handle `structured_content` that may not be directly JSON serializable.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d4d6f66-d7da-42ca-a82b-fdc61c9d1d68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d4d6f66-d7da-42ca-a82b-fdc61c9d1d68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

