### PR TITLE
Fix server calls and load all tools

### DIFF
--- a/intelligent_bot.py
+++ b/intelligent_bot.py
@@ -7,7 +7,7 @@ My smart assistant that understands what you need and does it for you
 import asyncio
 import json
 import os
-from mcp_service import ModernLLMService
+from modular_mcp_service import create_modular_service
 
 async def run_intelligent_bot():
     """Run my personal API assistant"""
@@ -25,17 +25,15 @@ async def run_intelligent_bot():
     print("Type 'quit' when you're done")
     print()
     
-    # Initialize the MCP service
-    print("🔄 Initializing MCP service...")
-    service = ModernLLMService()
-    success = await service.initialize()
-    
-    if not success:
-        print("❌ Failed to initialize MCP service")
+    # Initialize the modular MCP service
+    print("🔄 Initializing modular MCP service...")
+    try:
+        service = await create_modular_service(use_mock=False)
+        print("✅ Modular MCP service initialized successfully")
+    except Exception as e:
+        print(f"❌ Failed to initialize modular MCP service: {e}")
         print("Make sure your Azure credentials are configured")
         return
-    
-    print("✅ MCP service initialized with 51 tools")
     print()
     
     while True:
@@ -52,8 +50,11 @@ async def run_intelligent_bot():
             
             print("🧠 Analyzing your request...")
             
-            # Process with intelligent LLM service
-            result = await service.process_message(user_input)
+            # Process with modular MCP service
+            result = await service.process_message(
+                user_message=user_input,
+                session_id="cli_session"
+            )
             
             if 'error' in result:
                 print(f"❌ Error: {result['error']}")

--- a/llm_interface.py
+++ b/llm_interface.py
@@ -41,8 +41,18 @@ class AzureOpenAIProvider(LLMProvider):
         """Get or create Azure OpenAI client"""
         if self._client is None:
             try:
-                from mcp_client import create_azure_client
-                self._client = await create_azure_client()
+                from openai import AsyncOpenAI
+                api_key = os.getenv("AZURE_OPENAI_API_KEY")
+                endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+                
+                if not api_key or not endpoint:
+                    raise ValueError("AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT must be set")
+                
+                self._client = AsyncOpenAI(
+                    api_key=api_key,
+                    base_url=f"{endpoint}/openai/deployments/{self.deployment_name}",
+                    api_version=self.api_version
+                )
             except Exception as e:
                 logger.error(f"❌ [LLM_INTERFACE] Failed to create Azure client: {e}")
                 raise

--- a/modular_mcp_service.py
+++ b/modular_mcp_service.py
@@ -144,11 +144,14 @@ class ModularMCPService:
         try:
             logger.info("🔄 [MODULAR_SERVICE] Loading tools...")
             
-            # This would use the actual MCP client to load tools
-            # For now, return empty list as placeholder
-            tools = []
-            logger.info(f"✅ [MODULAR_SERVICE] Loaded {len(tools)} tools")
-            return tools
+            # Use the MCP client to load tools
+            if self.tool_executor and hasattr(self.tool_executor, 'mcp_client'):
+                tools = await list_and_prepare_tools(self.tool_executor.mcp_client)
+                logger.info(f"✅ [MODULAR_SERVICE] Loaded {len(tools)} tools")
+                return tools
+            else:
+                logger.warning("⚠️ [MODULAR_SERVICE] No MCP client available for tool loading")
+                return []
             
         except Exception as e:
             logger.error(f"❌ [MODULAR_SERVICE] Failed to load tools: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ mcp>=1.0.0
 httpx>=0.25.0
 pyyaml>=6.0
 asyncio
+fastmcp>=2.0.0
+openai>=1.0.0
+flask>=3.0.0
+flask-socketio>=5.0.0

--- a/test_tool_loading.py
+++ b/test_tool_loading.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Test Tool Loading - Verify Modular Service Loads All Tools
+========================================================
+Test script to verify that the modular MCP service loads all available tools
+from the MCP server.
+"""
+
+import asyncio
+import subprocess
+import time
+import signal
+import os
+from modular_mcp_service import create_modular_service
+
+async def test_tool_loading():
+    """Test that the modular service loads all tools from MCP server"""
+    print("🧪 Testing Tool Loading with Modular MCP Service")
+    print("=" * 60)
+    
+    # Start MCP server in background
+    print("🔄 Starting MCP server...")
+    server_process = subprocess.Popen([
+        "python3", "mcp_server_fastmcp2.py", "--transport", "stdio"
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    
+    # Wait a moment for server to start
+    time.sleep(2)
+    
+    try:
+        print("🔄 Creating modular MCP service...")
+        service = await create_modular_service(use_mock=False)
+        
+        print("🔄 Loading tools...")
+        tools = await service.get_available_tools()
+        
+        print(f"✅ Successfully loaded {len(tools)} tools")
+        print("\n📋 Tool List:")
+        print("-" * 40)
+        
+        for i, tool in enumerate(tools, 1):
+            name = tool.get('function', {}).get('name', 'unknown')
+            description = tool.get('function', {}).get('description', 'No description')
+            print(f"{i:2d}. {name}")
+            print(f"    {description}")
+            print()
+        
+        # Test a simple message processing
+        print("🔄 Testing message processing...")
+        result = await service.process_message(
+            user_message="What tools are available?",
+            session_id="test_session"
+        )
+        
+        print(f"✅ Message processed successfully")
+        print(f"   Response: {result.get('response', 'No response')[:100]}...")
+        
+        await service.cleanup()
+        print("✅ Test completed successfully")
+        
+    except Exception as e:
+        print(f"❌ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+    
+    finally:
+        # Clean up server process
+        print("🔄 Stopping MCP server...")
+        server_process.terminate()
+        server_process.wait()
+        print("✅ MCP server stopped")
+
+if __name__ == "__main__":
+    asyncio.run(test_tool_loading())


### PR DESCRIPTION
Migrate to `ModularMCPService` and fix tool loading to ensure all available tools are loaded from the MCP server.

The previous `ModernLLMService` only loaded a limited number of tools (2) and did not fully leverage the modular architecture. The `_load_tools` method in the new modular service was a placeholder, preventing proper tool discovery. This PR updates the core services and applications to use the `ModularMCPService` and implements the correct tool loading mechanism, resolving the issue of limited tool availability. It also streamlines the LLM client initialization by directly using the `openai` package.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e5502aa-f14b-4d7d-b260-d9ecdb75871f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e5502aa-f14b-4d7d-b260-d9ecdb75871f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

